### PR TITLE
Feature probe in physical order

### DIFF
--- a/libavformat/avio.h
+++ b/libavformat/avio.h
@@ -692,6 +692,18 @@ int avio_get_str16be(AVIOContext *pb, int maxlen, char *buf, int buflen);
  */
 #define AVIO_FLAG_NONBLOCK 8
 
+/*
+ * Use non-seek mode.
+ * If this flag is set, read frame from context will ignore seekable flag
+ * in AVIOContext, and return frame as if the context is non-seekable,
+ * so that the packet is returned in it's physical order
+ * Warning: only can be used by ffprobe, and some format may not support 
+ * this flag.
+ * support list:
+ * 1. mov,mp4,m4a,3gp,3g2,mj2
+ */
+#define AVIO_FLAG_PHYSICAL_ORDER_FRAME  16
+
 /**
  * Use direct mode.
  * avio_read and avio_write should if possible be satisfied directly
@@ -699,6 +711,7 @@ int avio_get_str16be(AVIOContext *pb, int maxlen, char *buf, int buflen);
  * call the underlying seek function directly.
  */
 #define AVIO_FLAG_DIRECT 0x8000
+
 
 /**
  * Create and initialize a AVIOContext for accessing the

--- a/libavformat/mov.c
+++ b/libavformat/mov.c
@@ -7640,8 +7640,8 @@ static AVIndexEntry *mov_find_next_sample(AVFormatContext *s, AVStream **st)
             int64_t dts = av_rescale(current_sample->timestamp, AV_TIME_BASE, msc->time_scale);
             av_log(s, AV_LOG_TRACE, "stream %d, sample %d(%p), dts %"PRId64", pos %"PRId64"\n",
                     i, msc->current_sample, (void*)current_sample, dts, current_sample->pos);
-            if (!sample || (!(s->pb->seekable & AVIO_SEEKABLE_NORMAL) && current_sample->pos < sample->pos) ||
-                ((s->pb->seekable & AVIO_SEEKABLE_NORMAL) &&
+            if (!sample || ((!(s->pb->seekable & AVIO_SEEKABLE_NORMAL) || s->avio_flags & AVIO_FLAG_PHYSICAL_ORDER_FRAME) && current_sample->pos < sample->pos) ||
+                ((s->pb->seekable & AVIO_SEEKABLE_NORMAL) && !(s->avio_flags & AVIO_FLAG_PHYSICAL_ORDER_FRAME) &&
                  ((msc->pb != s->pb && dts < best_dts) || (msc->pb == s->pb &&
                  ((FFABS(best_dts - dts) <= AV_TIME_BASE && current_sample->pos < sample->pos) ||
                   (FFABS(best_dts - dts) > AV_TIME_BASE && dts < best_dts)))))) {
@@ -7651,8 +7651,8 @@ static AVIndexEntry *mov_find_next_sample(AVFormatContext *s, AVStream **st)
             }
         }
     }
-    av_log(s, AV_LOG_TRACE, "selected sample is %p, max dts jitter %"PRId64"\n",
-            (void*)sample, max_dts_jitter);
+    av_log(s, AV_LOG_TRACE, "selected sample is %p\n",
+            (void*)sample);
     return sample;
 }
 

--- a/libavformat/mov.c
+++ b/libavformat/mov.c
@@ -7638,7 +7638,8 @@ static AVIndexEntry *mov_find_next_sample(AVFormatContext *s, AVStream **st)
         if (msc->pb && msc->current_sample < avst->nb_index_entries) {
             AVIndexEntry *current_sample = &avst->index_entries[msc->current_sample];
             int64_t dts = av_rescale(current_sample->timestamp, AV_TIME_BASE, msc->time_scale);
-            av_log(s, AV_LOG_TRACE, "stream %d, sample %d, dts %"PRId64"\n", i, msc->current_sample, dts);
+            av_log(s, AV_LOG_TRACE, "stream %d, sample %d(%p), dts %"PRId64", pos %"PRId64"\n",
+                    i, msc->current_sample, (void*)current_sample, dts, current_sample->pos);
             if (!sample || (!(s->pb->seekable & AVIO_SEEKABLE_NORMAL) && current_sample->pos < sample->pos) ||
                 ((s->pb->seekable & AVIO_SEEKABLE_NORMAL) &&
                  ((msc->pb != s->pb && dts < best_dts) || (msc->pb == s->pb &&
@@ -7650,6 +7651,8 @@ static AVIndexEntry *mov_find_next_sample(AVFormatContext *s, AVStream **st)
             }
         }
     }
+    av_log(s, AV_LOG_TRACE, "selected sample is %p, max dts jitter %"PRId64"\n",
+            (void*)sample, max_dts_jitter);
     return sample;
 }
 

--- a/libavformat/options_table.h
+++ b/libavformat/options_table.h
@@ -36,6 +36,7 @@
 static const AVOption avformat_options[] = {
 {"avioflags", NULL, OFFSET(avio_flags), AV_OPT_TYPE_FLAGS, {.i64 = DEFAULT }, INT_MIN, INT_MAX, D|E, "avioflags"},
 {"direct", "reduce buffering", 0, AV_OPT_TYPE_CONST, {.i64 = AVIO_FLAG_DIRECT }, INT_MIN, INT_MAX, D|E, "avioflags"},
+{"frame_natural", "physical order", 1, AV_OPT_TYPE_CONST, {.i64 = AVIO_FLAG_PHYSICAL_ORDER_FRAME }, INT_MIN, INT_MAX, D|E, "avioflags"},
 {"probesize", "set probing size", OFFSET(probesize), AV_OPT_TYPE_INT64, {.i64 = 5000000 }, 32, INT64_MAX, D},
 {"formatprobesize", "number of bytes to probe file format", OFFSET(format_probesize), AV_OPT_TYPE_INT, {.i64 = PROBE_BUF_MAX}, 0, INT_MAX-1, D},
 {"packetsize", "set packet size", OFFSET(packet_size), AV_OPT_TYPE_INT, {.i64 = DEFAULT }, 0, INT_MAX, E},


### PR DESCRIPTION
when probe and show frames, we can try to get frame information in natural order other than adjusted by demuxer
support mp4 first